### PR TITLE
feat: add edge runner variants for binary and code scan workflows

### DIFF
--- a/.cloudbees/scanners/binary_scan_edge.yaml
+++ b/.cloudbees/scanners/binary_scan_edge.yaml
@@ -1,0 +1,137 @@
+apiVersion: automation.cloudbees.io/v1alpha1
+kind: workflow
+name:  binary_scan
+
+permissions:
+  scm-token-own: read
+  id-token: write
+
+jobs:
+  scan:
+    runs-on: [self-hosted]
+    steps:
+      - name: Initiate execution plan
+        uses: https://github.com/cloudbees-io/asset-chain-utils-preprod/start-chain@v1
+        id: plan
+
+      # Login to AWS if region and role arn are provided to pull private images from ECR
+      - name: Login to AWS
+        if: ${{ steps.plan.outputs.ecr_region_name != 'false' && steps.plan.outputs.ecr_role_arn != 'false' }}
+        uses: https://github.com/cloudbees-io/configure-aws-credentials@v1
+        id: aws-login
+        with:
+          aws-region: ${{ steps.plan.outputs.ecr_region_name }}
+          role-to-assume: ${{ steps.plan.outputs.ecr_role_arn }}
+          role-duration-seconds: "3600"
+
+      - name: ECR Artifact Inventory
+        if: ${{ steps.plan.outputs.ecr-inventory == 'true' }}
+        env:
+          INPUT_AWS_REGION: ${{ steps.plan.outputs.ecr_region_name }}
+          EXECUTION_ROLE: "MASTER"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-aws-ecr:latest
+        run: /app/plugin-aws-ecr -mode single
+
+      - name: ECR Artifact Metadata
+        if: ${{ steps.plan.outputs.ecr-metadata == 'true' }}
+        env:
+          INPUT_AWS_REGION: ${{ steps.plan.outputs.ecr_region_name }}
+          EXECUTION_ROLE: "DECORATOR"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-aws-ecr:latest
+        run: /app/plugin-aws-ecr -mode single
+
+      - name: Workflow Artifact Inventory
+        if: ${{ steps.plan.outputs.wfartifact-inventory == 'true' }}
+        env:
+          INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
+          INPUT_WF_ARTIFACT_TOKEN: ${{ steps.plan.outputs.wf_artifact_token }}
+          INPUT_COMPONENT_ID: ${{ steps.plan.outputs.wf_artifact_component_id }}
+          EXECUTION_ROLE: "MASTER"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-cbp-workflow-artifacts:latest
+        run: /app/plugin-cbp-workflow-artifacts -mode single
+
+      - name: Workflow Artifact Metadata
+        if: ${{ steps.plan.outputs.wfartifact-decorator == 'true' }}
+        env:
+          INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
+          INPUT_WF_ARTIFACT_TOKEN: ${{ steps.plan.outputs.wf_artifact_token }}
+          INPUT_COMPONENT_ID: ${{ steps.plan.outputs.wf_artifact_component_id }}
+          EXECUTION_ROLE: "DECORATOR"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-cbp-workflow-artifacts:latest
+        run: /app/plugin-cbp-workflow-artifacts -mode single
+
+      - name: JFrog Artifactory Inventory
+        if: ${{ steps.plan.outputs.jfrog-inventory == 'true' }}
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "MASTER"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-jfrog-artifactory:latest
+        run: /app/plugin-jfrog -mode single
+
+      - name: JFrog Artifactory Metadata
+        if: ${{ steps.plan.outputs.jfrog-metadata == 'true' }}
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "DECORATOR"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-jfrog-artifactory:latest
+        run: /app/plugin-jfrog -mode single
+
+      - name: Nexus Repository Inventory
+        if: ${{ steps.plan.outputs.nexus-inventory == 'true' }}
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "MASTER"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-nexus-repository:latest
+        run: /app/plugin-nexus -mode single
+
+      - name: Nexus Repository Metadata
+        if: ${{ steps.plan.outputs.nexus-metadata == 'true' }}
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "DECORATOR"
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-nexus-repository:latest
+        run: /app/plugin-nexus -mode single
+
+      - name: Trivy Scanner
+        if: ${{ steps.plan.outputs.trivy == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-trivy-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-trivy-scanner -mode single
+
+      - name: FindSecBugs Scanner
+        if: ${{ steps.plan.outputs.findsecbugs == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-findsecbugs-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-findsecbugs -mode single
+
+      - name: Syft SBOM analyser
+        if: ${{ steps.plan.outputs.syft == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-syft-sbom:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-syftbom-analyser -mode single
+
+      - name: Grype Scanner
+        if: ${{ steps.plan.outputs.grype == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-grype-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-grype-scanner -mode single
+
+      - name: Complete execution plan
+        uses: https://github.com/cloudbees-io/asset-chain-utils-preprod/end-chain@v1
+        id: process-outputs

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -1,0 +1,223 @@
+apiVersion: automation.cloudbees.io/v1alpha1
+kind: workflow
+name:  scan
+
+#permissions:
+#  scm-token-own: read
+#  id-token: write
+
+jobs:
+  scan:
+    runs-on: [self-hosted]
+    steps:
+      - name: Initiate execution plan
+        uses: https://github.com/cloudbees-io/asset-chain-utils-preprod/start-chain@v1
+        id: plan
+
+      - name: Github Inventory
+        if: ${{ steps.plan.outputs.github-inventory == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-github-inventory:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          CH_LOG_LEVEL: trace
+        run: /app/plugin-git-master -mode single
+      - name: Github Metadata
+        if: ${{ steps.plan.outputs.github-decorator == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-github-metadata:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+        run: /app/plugin-git-decorator -mode single
+
+      - name: Bitbucket Inventory
+        if: ${{ steps.plan.outputs.bitbucket-inventory == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-bitbucket-server:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "MASTER"
+        run: /app/plugin-bitbucket -mode single
+
+      - name: Bitbucket Metadata
+        if: ${{ steps.plan.outputs.bitbucket-decorator == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-bitbucket-server:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "DECORATOR"
+        run: /app/plugin-bitbucket -mode single
+
+      - name: Gerrit Inventory
+        if: ${{ steps.plan.outputs.gerrit-inventory == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-gerrit:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "MASTER"
+        run: /app/plugin-gerrit -mode single
+
+      - name: Gerrit Metadata
+        if: ${{ steps.plan.outputs.gerrit-decorator == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-gerrit:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "DECORATOR"
+        run: /app/plugin-gerrit -mode single
+
+      - name: GitLab Inventory
+        if: ${{ steps.plan.outputs.gitlab-inventory == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-gitlab:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "MASTER"
+        run: /app/plugin-gitlab -mode single
+
+      - name: GitLab Metadata
+        if: ${{ steps.plan.outputs.gitlab-decorator == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-gitlab:latest
+        env:
+          ACCOUNT_CREDENTIALS: ${{ steps.plan.outputs.account_credentials}}
+          EXECUTION_ROLE: "DECORATOR"
+        run: /app/plugin-gitlab -mode single
+
+      - name: SCC Scanner
+        if: ${{ steps.plan.outputs.scc == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-scc-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        run: /app/plugin-scc-scanner -mode single
+
+      - name: GoSec Scanner
+        if: ${{ steps.plan.outputs.gosec == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-gosec-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+          GOSEC_FORCE_SCAN: true
+          GOSEC_AST_BUDGET_RATIO: 0.9
+        continue-on-error: true
+        run: /app/plugin-gosec-scanner -mode single
+
+      - name: Njs Scanner
+        if: ${{ steps.plan.outputs.njsscan == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-njsscan-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-njsscan-scanner -mode single
+
+      - name: Gitleaks Scanner
+        if: ${{ steps.plan.outputs.gitleaks == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-gitleaks-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-gitleaks-scanner -mode single
+
+      - name: BlackDuck Scanner
+        if: ${{ steps.plan.outputs.blackduck == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/plugin-blackduck-sca:latest
+        env:
+          BLACKDUCK_PROPS : ${{ steps.plan.outputs.blackduck-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-blackduck-scanner -mode single
+
+      - name: Coverity Polaris Scanner
+        if: ${{ steps.plan.outputs.coverity == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/plugin-coverity-sca:latest
+        env:
+          COVERITY_PROPS : ${{ steps.plan.outputs.coverity-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        timeout-minutes: 30
+        run: /app/plugin-coverity-polaris -mode single
+
+      - name: Checkov Scanner
+        if: ${{ steps.plan.outputs.checkov == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-checkov-scanner:latest
+        env:
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-checkov -mode single
+
+      - name: Snyk SAST Scanner
+        if: ${{ steps.plan.outputs.snykcode == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-snyk-sast-scanner:latest
+        env:
+          SNYK_SAST_PROPS: ${{ steps.plan.outputs.snykcode-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-snyk-sast-scanner -mode single
+
+      - name: Snyk IaC Scanner
+        if: ${{ steps.plan.outputs.snyk-iac == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-snyk-iac-scanner:latest
+        env:
+          SNYK_IAC_PROPS: ${{ steps.plan.outputs.snyk-iac-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-snyk-iac-scanner -mode single
+
+      - name: Snyk SCA Scanner
+        if: ${{ steps.plan.outputs.snyksca == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-snyk-sca-scanner:latest
+        env:
+          SNYK_SCA_PROPS: ${{ steps.plan.outputs.snyksca-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-snyk-sca-scanner -mode single
+
+      - name: Checkmarxone SAST Scanner
+        if: ${{ steps.plan.outputs.checkmarxone-sast == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-checkmarxone-sast-scanner:latest
+        env:
+          CHECKMARXONE_SAST_PROPS: ${{ steps.plan.outputs.checkmarxone-sast-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-checkmarxone-sast-scanner -mode single
+
+      - name: Perforce Klocwork Scanner
+        if: ${{ steps.plan.outputs.perforce-klocwork-sast == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-klocwork-scanner:latest
+        env:
+          KLOCWORK_PROPS: ${{ steps.plan.outputs.perforce-klocwork-sast-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-klocwork-scanner -mode single
+
+       # PLease do not move the position of sonarqube plugin in the list as it is creating permission issues for other plugin
+       # To be addressed on the ticket
+      - name: Sonar Scanner
+        if: ${{ steps.plan.outputs.sonar == 'true' }}
+        uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-sonarqube-scanner:latest
+        env:
+          SONARQUBE_PROPS : ${{ steps.plan.outputs.sonar-props}}
+          RUN_ID: ${{ cloudbees.run_id }}
+          JOB_ID: ${{ job.id }}
+          STEP_ID: ${{ step.internal.id }}
+        continue-on-error: true
+        run: /app/plugin-sonarqube-scanner -mode single
+
+      - name: Complete execution plan
+        uses: https://github.com/cloudbees-io/asset-chain-utils-preprod/end-chain@v1
+        id: process-outputs


### PR DESCRIPTION
## Summary

- Adds `binary_scan_edge.yaml` — edge runner variant of `binary_scan.yaml`
- Adds `code_scan_edge.yaml` — edge runner variant of `code_scan.yaml`

Both files are identical to their non-edge counterparts except for `runs-on: [self-hosted]` on the job, which routes scans to registered edge runners. All preprod-specific details are preserved: `asset-chain-utils-preprod` action references and private ECR image URLs (`020229604682.dkr.ecr.us-east-1.amazonaws.com`).

These workflows are required for the `EdgeScanRouting` feature flag path in asset-service, which routes implicit scans to `.cloudbees/scanners/{type}_scan_edge.yaml` when the flag is enabled for an org and edge runners are registered.

## Test plan

- [x] Enable `EdgeScanRouting` feature flag for a test org in preprod
- [x] Register an edge runner for that org
- [ ] Trigger an implicit scan and confirm it dispatches via `code_scan_edge.yaml` on the edge runner
- [ ] Trigger a binary scan and confirm it dispatches via `binary_scan_edge.yaml` on the edge runner