### PR TITLE
feat(CBP-46173): wire edge-redaction suppress-logs into code_scan_edge (preprod)

### DIFF
--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -89,6 +89,9 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46173): suppress this code scanner's logs (can quote
+          # source). Code/SAST steps only; index+default so an unset var → "false".
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         run: /app/plugin-scc-scanner -mode single
 
       - name: GoSec Scanner
@@ -100,6 +103,7 @@ jobs:
           STEP_ID: ${{ step.internal.id }}
           GOSEC_FORCE_SCAN: true
           GOSEC_AST_BUDGET_RATIO: 0.9
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-gosec-scanner -mode single
 
@@ -110,6 +114,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-njsscan-scanner -mode single
 
@@ -120,6 +125,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-gitleaks-scanner -mode single
 
@@ -153,6 +159,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkov -mode single
 
@@ -164,6 +171,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-sast-scanner -mode single
 
@@ -175,6 +183,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-iac-scanner -mode single
 
@@ -197,6 +206,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkmarxone-sast-scanner -mode single
 
@@ -208,6 +218,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-klocwork-scanner -mode single
 
@@ -221,6 +232,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-sonarqube-scanner -mode single
 


### PR DESCRIPTION
## What
Sets `CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}` on the 10 code/SAST scanner steps in `code_scan_edge.yaml` (SCC, GoSec, Njsscan, Gitleaks, Checkov, Snyk SAST, Snyk IaC, Checkmarxone SAST, Klocwork, Sonar).

SCA scanners (BlackDuck, Coverity Polaris, Snyk SCA) are intentionally **excluded** — their output is package metadata, not source.

## Why
Preprod counterpart to compliance-workflows#57, so the edge log-suppression chain (dsl-engine-cli#799 mechanism, #804 engine gating) can be validated on preprod/QA before the prod change lands. Without this, an edge code scan on preprod has nothing setting the env var, so suppression can't be exercised.

The engine (dsl-engine-cli#804) reads `CLOUDBEES_SUPPRESS_LOGS` and appends `--suppress-logs` to the runtime CLI for that step.