### PR TITLE
feat(CBP-46171): pass EDGE_REDACTION_STRIP_BASEDATA to end-chain on edge

### DIFF
--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -239,3 +239,5 @@ jobs:
       - name: Complete execution plan
         uses: https://github.com/cloudbees-io/asset-chain-utils-preprod/end-chain@v1
         id: process-outputs
+        with:
+          edge-redaction-strip-basedata: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}


### PR DESCRIPTION
[CBP-46171](https://cloudbees.atlassian.net/browse/CBP-46171)

## What

Pass the edge-redaction strip-base-data flag into the end-chain step of the edge code-scan workflow, so source code in code-scanner `BaseData` is stripped before results leave the edge runner.

## Change

`code_scan_edge.yaml` — the end-chain step now sets:

```yaml
with:
  edge-redaction-strip-basedata: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
```

The value originates in asset-service (emitted onto the execution plan for edge scans), surfaced by start-chain as an output. end-chain forwards it to `process-outputs`, which nils BaseData on code-scanner findings.

## Scope

- **Code scan only.** `binary_scan_edge.yaml` is intentionally not wired — Trivy (our only binary scanner) reports `AssetType=="BINARY"`, which `process-outputs` passes through anyway (package metadata, no source).
- **Edge only.** Cloud workflows don't receive the var; empty value → no redaction.

## Dependency

Requires the action-manifest change first: cloudbees-io/asset-chain-utils-preprod#46 (adds the `edge-redaction-strip-basedata` input on end-chain and the output on start-chain). Merge/deploy that before this, or the `with:` input is undefined on the pinned action version.

## Related

- Consumer logic: calculi-corp/assets-plugin-chain-utils#180
- Producer: asset-service #1670, api-proto #134

[CBP-46171]: https://cloudbees.atlassian.net/browse/CBP-46171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ