### PR TITLE
fix(CBP-46173): read suppress-logs from plan output, not a workflow var

### DIFF
--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -90,8 +90,10 @@ jobs:
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
           # Edge redaction (CBP-46173): suppress this code scanner's logs (can quote
-          # source). Code/SAST steps only; index+default so an unset var → "false".
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          # source). Reads the value asset-service puts on the execution plan, surfaced
+          # by start-chain as a plan output (same channel as EDGE_REDACTION_STRIP_BASEDATA).
+          # Code/SAST steps only; default to "false" when absent.
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         run: /app/plugin-scc-scanner -mode single
 
       - name: GoSec Scanner
@@ -103,7 +105,7 @@ jobs:
           STEP_ID: ${{ step.internal.id }}
           GOSEC_FORCE_SCAN: true
           GOSEC_AST_BUDGET_RATIO: 0.9
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-gosec-scanner -mode single
 
@@ -114,7 +116,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-njsscan-scanner -mode single
 
@@ -125,7 +127,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-gitleaks-scanner -mode single
 
@@ -159,7 +161,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkov -mode single
 
@@ -171,7 +173,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-sast-scanner -mode single
 
@@ -183,7 +185,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-iac-scanner -mode single
 
@@ -206,7 +208,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkmarxone-sast-scanner -mode single
 
@@ -218,7 +220,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
         continue-on-error: true
         run: /app/plugin-klocwork-scanner -mode single
 
@@ -232,7 +234,7 @@ jobs:
       #     RUN_ID: ${{ cloudbees.run_id }}
       #     JOB_ID: ${{ job.id }}
       #     STEP_ID: ${{ step.internal.id }}
-      #     CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
+      #     CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
       #   continue-on-error: true
       #   run: /app/plugin-sonarqube-scanner -mode single
 

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -92,8 +92,10 @@ jobs:
           # Edge redaction (CBP-46173): suppress this code scanner's logs (can quote
           # source). Reads the value asset-service puts on the execution plan, surfaced
           # by start-chain as a plan output (same channel as EDGE_REDACTION_STRIP_BASEDATA).
-          # Code/SAST steps only; default to "false" when absent.
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          # Index syntax (not .field) so a missing output resolves to null → "false"
+          # rather than an undefined-identifier error (e.g. flag-off / manual run).
+          # Code/SAST steps only.
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         run: /app/plugin-scc-scanner -mode single
 
       - name: GoSec Scanner
@@ -105,7 +107,7 @@ jobs:
           STEP_ID: ${{ step.internal.id }}
           GOSEC_FORCE_SCAN: true
           GOSEC_AST_BUDGET_RATIO: 0.9
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-gosec-scanner -mode single
 
@@ -116,7 +118,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-njsscan-scanner -mode single
 
@@ -127,7 +129,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-gitleaks-scanner -mode single
 
@@ -161,7 +163,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkov -mode single
 
@@ -173,7 +175,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-sast-scanner -mode single
 
@@ -185,7 +187,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-iac-scanner -mode single
 
@@ -208,7 +210,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkmarxone-sast-scanner -mode single
 
@@ -220,7 +222,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-klocwork-scanner -mode single
 
@@ -234,7 +236,7 @@ jobs:
       #     RUN_ID: ${{ cloudbees.run_id }}
       #     JOB_ID: ${{ job.id }}
       #     STEP_ID: ${{ step.internal.id }}
-      #     CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
+      #     CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
       #   continue-on-error: true
       #   run: /app/plugin-sonarqube-scanner -mode single
 


### PR DESCRIPTION
## Problem
The `CLOUDBEES_SUPPRESS_LOGS` env on the code/SAST scanner steps (added in #106) read:
```
${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
```
But asset-service never sets a workflow var by that name. It emits `EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS` onto the **execution plan** (`plan.Envs`), which `start-chain`'s configure step surfaces as a **step output** (`steps.plan.outputs.*`) — a different namespace from `vars`. So the expression always fell through to `|| 'false'` and suppression was permanently off, regardless of the org's redaction config.

## Fix
Read from the channel the value actually arrives on:
```
${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS || 'false' }}
```
This is the same pattern the working `EDGE_REDACTION_STRIP_BASEDATA` flag already uses (end-chain step, line ~243). No producer or configure-step change needed — the bridge already exists.

Applied to all 9 active code/SAST scanner steps + the commented-out Sonar block (for consistency on re-enable). SCA scanners (BlackDuck, Coverity Polaris, Snyk SCA) remain untouched. Preserves the `|| 'false'` safe default. YAML validated.

## Follow-up
The prod counterpart (compliance-workflows#57) carries the same `vars[...]` bug and needs the same fix before it merges.