### PR TITLE
feat(CBP-46177): pass EDGE_REDACTION_SWEEP_SARIF to end-chain on edge

### DIFF
--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -245,3 +245,4 @@ jobs:
         id: process-outputs
         with:
           edge-redaction-strip-basedata: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
+          edge-redaction-sweep-sarif: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}


### PR DESCRIPTION
[CBP-46177](https://cloudbees.atlassian.net/browse/CBP-46177)

## What
`code_scan_edge.yaml` end-chain step now forwards start-chain's `EDGE_REDACTION_SWEEP_SARIF` output:
```yaml
with:
  edge-redaction-sweep-sarif: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}
```
so `process-outputs` strips source snippets from workspace `.sarif` files before results leave the edge runner.

## Scope
Code scan only; edge only (cloud workflows don't receive the var, empty → no sweep). Same channel as `EDGE_REDACTION_STRIP_BASEDATA` (#107).

## Dependency
Requires the action-manifest change first: cloudbees-io/asset-chain-utils-preprod#48 (adds the `edge-redaction-sweep-sarif` input + start-chain output). Merge/deploy that before this, or the `with:` input is undefined on the pinned action version.

[CBP-46177]: https://cloudbees.atlassian.net/browse/CBP-46177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ