### PR TITLE
feat(CBP-46178): feed suppress-code-scanner-logs output to end-chain

### DIFF
--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -246,3 +246,4 @@ jobs:
         with:
           edge-redaction-strip-basedata: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
           edge-redaction-sweep-sarif: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}
+          edge-redaction-suppress-code-scanner-logs: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS }}


### PR DESCRIPTION
## What
`code_scan_edge.yaml` now passes `steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS` into the end-chain action's new `edge-redaction-suppress-code-scanner-logs` input.

## Why
Completes the wiring so end-chain prints the on-premise log-retention notice (CBP-46178) on edge scans where code-scanner logs were suppressed. Mirrors the existing strip-basedata/sweep-sarif lines.

## Companion PRs
- asset-chain-utils-preprod#50 (end-chain input → env)
- assets-plugin-chain-utils#195 (prints the notice)

Merge order: #195 + #50 first (and move end-chain `v1` tag), then this.